### PR TITLE
修复可能删除整个数据文件夹的漏洞

### DIFF
--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -20,13 +20,14 @@ module FakeS3
     method_option :corspreflightallowheaders, :type => :string, :desc => 'Access-Control-Allow-Headers header return value for preflight OPTIONS requests'
     method_option :corspostputallowheaders, :type => :string, :desc => 'Access-Control-Allow-Headers header return value for POST and PUT requests'
     method_option :corsexposeheaders, :type => :string, :desc => 'Access-Control-Expose-Headers header return value'
+    method_option :enable_remove_bucket, :type => :boolean, :desc => "Enable to remove bucket.Default false."
 
     def server
       store = nil
       if options[:root]
         root = File.expand_path(options[:root])
         # TODO Do some sanity checking here
-        store = FileStore.new(root, !!options[:quiet])
+        store = FileStore.new(root, !!options[:quiet], !!options[:enable_remove_bucket])
       end
 
       if store.nil?

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -359,7 +359,7 @@ module FakeS3
         @store.delete_objects(bucket_obj,keys,s_req.webrick_request)
       when Request::DELETE_OBJECT
         bucket_obj = @store.get_bucket(s_req.bucket)
-        @store.delete_object(bucket_obj,s_req.object,s_req.webrick_request)
+        @store.delete_object(bucket_obj,s_req.object, request)
       when Request::DELETE_BUCKET
         @store.delete_bucket(s_req.bucket)
       end


### PR DESCRIPTION
1. 修复只穿了key的文件夹部分导致某文件夹所有文件被删除的问题
2. 启动fake s3时，指定参数enable_remove_bucket,默认为false
3. Delete Bucket时，根据enable_remove_bucket确定是否执行删除逻辑，默认不执行
